### PR TITLE
Added support for kernels before 2.6.27

### DIFF
--- a/src/bindings.cc
+++ b/src/bindings.cc
@@ -110,8 +110,13 @@ namespace NodeInotify {
             inotify = new Inotify();
         }
 
-        inotify->fd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC); //nonblock
-        //inotify->fd = inotify_init1(IN_CLOEXEC); //block
+        #ifdef INOTIFY_INIT1
+            inotify->fd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC); //nonblock
+            //inotify->fd = inotify_init1(IN_CLOEXEC); //block
+        #else
+            //old kernel versions don't have nonblock implemented yet
+            inotify->fd = inotify_init();
+        #endif
 
         if(inotify->fd == -1) {
             ThrowException(String::New(strerror(errno)));

--- a/src/wscript
+++ b/src/wscript
@@ -8,7 +8,8 @@ def configure(conf):
   conf.check_tool("compiler_cxx")
   conf.check_tool("node_addon")
   conf.find_program('node', var='NODE', mandatory=True)
-  conf.check_cxx(header_name="sys/inotify.h", function_name="inotify_init1")
+  conf.check_cxx(header_name="sys/inotify.h", function_name="inotify_init", mandatory=True)
+  conf.check_cxx(header_name="sys/inotify.h", function_name="inotify_init1", define_name="INOTIFY_INIT1")
 
 def build(bld):
   obj = bld.new_task_gen("cxx", "shlib", "node_addon")


### PR DESCRIPTION
inotify_init1() doesn't exist on kernels before 2.6.27, but using inotify_init() with this module still works.  I have implemented and tested this and it's working smoothly.

Thanks,
-Brian
