### PR TITLE
Compatibility with node v0.5.2+

### DIFF
--- a/src/bindings.cc
+++ b/src/bindings.cc
@@ -20,7 +20,6 @@ namespace NodeInotify {
     void Inotify::Initialize(Handle<Object> target) {
         Local<FunctionTemplate> t = FunctionTemplate::New(Inotify::New);
 
-        t->Inherit(EventEmitter::constructor_template);
         t->InstanceTemplate()->SetInternalFieldCount(1);
 
         NODE_SET_PROTOTYPE_METHOD(t, "addWatch",
@@ -79,13 +78,13 @@ namespace NodeInotify {
         target->Set(String::NewSymbol("Inotify"), t->GetFunction());
     }
 
-    Inotify::Inotify() : EventEmitter() {
+    Inotify::Inotify() : ObjectWrap() {
         ev_init(&read_watcher, Inotify::Callback);
         read_watcher.data = this;  //preserving my reference to use it inside Inotify::Callback
         persistent = true;
     }
 
-    Inotify::Inotify(bool nonpersistent) : EventEmitter() {
+    Inotify::Inotify(bool nonpersistent) : ObjectWrap() {
         ev_init(&read_watcher, Inotify::Callback);
         read_watcher.data = this;  //preserving my reference to use it inside Inotify::Callback
         persistent = nonpersistent;

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -5,7 +5,7 @@
 
 namespace NodeInotify {
 
-    class Inotify : public EventEmitter {
+    class Inotify : public ObjectWrap {
         public:
             static void Initialize(Handle<Object> target);
 

--- a/src/node_inotify.h
+++ b/src/node_inotify.h
@@ -3,7 +3,7 @@
 #define SRC_NODE_INOTIFY_H_
 
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 #include <sys/inotify.h>
 #include <sys/select.h>
 #include <errno.h>


### PR DESCRIPTION
Hi !

I've fixed the module compatibility with node v0.5.x because EventEmitter was moved from something accessible in C++ to pure JavaScript.
