### PR TITLE
fix up inotify read loop to not lose events

### DIFF
--- a/src/bindings.cc
+++ b/src/bindings.cc
@@ -256,8 +256,10 @@ namespace NodeInotify {
         TryCatch try_catch;
 
         int i = 0;
-        while (i < read(inotify->fd, buffer, BUF_LEN)) {
-            struct inotify_event *event;
+	int sz = 0;
+        while ((sz = read(inotify->fd, buffer, BUF_LEN)) > 0) {
+	  struct inotify_event *event;
+	  for (i = 0; i <= (sz-EVENT_SIZE); i += (EVENT_SIZE + event->len)) {
             event = (struct inotify_event *) &buffer[i];
 
             Local<Object> obj = Object::New();
@@ -286,9 +288,8 @@ namespace NodeInotify {
             if (try_catch.HasCaught()) {
                 FatalException(try_catch);
             }
-
-            i += EVENT_SIZE + event->len;
-        }
+	  }
+	}
     }
 
     Handle<Value> Inotify::GetPersistent(Local<String> property,


### PR DESCRIPTION
I sent this (not knowing any better) to your gmail account the other day, Camilo. Now I know better ;-). Just a patch really to get the inotify code to scale up a bit. After the change, it doesn't lose events, and I can get 2 test processes (one creating files if they don't exist and then sleeping for a short amount of time and the other noticing the creation and deleting said files) to do 20 such files create/inotify/deletes at 10K creations/sec on my laptop, with only occasional points where the creating code wants to create the file again and can't because the other node process hasn't yet deleted it. Hope this helps.
