### PR TITLE
Remove node-waf dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
             "type": "git",
             "url": "http://github.com/c4milo/node-inotify"
      },
-    "scripts": {
-       "install": "node-waf configure build"
-    },
     "engines": {"node": "0.8"},
     "main" : "inotify"
 }


### PR DESCRIPTION
We're already requiring node >= 0.8, so it makes no sense to have an npm install script executing node-waf anymore.
