### PR TITLE
Node 0.10.0 compatiblity

### DIFF
--- a/src/node_inotify.cc
+++ b/src/node_inotify.cc
@@ -23,3 +23,4 @@ namespace NodeInotify {
     }
 } //namespace NodeInotify
 
+NODE_MODULE(inotify, NodeInotify::init)


### PR DESCRIPTION
The current master does not compile correctly with node 0.10.0. When requiring node-inotify it results in an error:
Error: Cannot find module './build/Debug/inotify'

This is due to the try-catch around requiring the Release version. The error from the Release version is:
Symbol inotify_module not found.

This fix resolves that problem.
