### PR TITLE
Use nan scope to Try_catch obj and FatalException()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inotify",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": "Camilo Aguilar <camilo.aguilar@gmail.com>",
   "email": "camilo.aguilar@gmail.com",
   "keywords": [

--- a/src/bindings.cc
+++ b/src/bindings.cc
@@ -250,7 +250,7 @@ namespace NodeInotify {
 		//int length = read(inotify->fd, buffer, BUF_LEN);
 
 		Local<Value> argv[1];
-		TryCatch try_catch;
+		Nan::TryCatch try_catch;
 
 		int sz = 0;
 		while ((sz = read(inotify->fd, buffer, BUF_LEN)) > 0) {
@@ -285,7 +285,7 @@ namespace NodeInotify {
 				}
 
 				if (try_catch.HasCaught()) {
-					FatalException(try_catch);
+					Nan::FatalException(try_catch);
 				}
 			} // for
 		} // while


### PR DESCRIPTION
This change addresses compiler warning regarding use of deprecated FatelException() interface.   The new V8 interface requires an Isolate object.   Corresponding NAN interface takes of this carries on with the older simpler interface.   

I tested with node version 4.1.2 and nan version 2.1.0.  On x86_64 (64bit).

