### PR TITLE
update compatibility with Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 env:
   - CXX="g++-4.8"
 node_js:
+  - "10"
   - "8"
   - "7"
   - "6"

--- a/src/node_inotify.cc
+++ b/src/node_inotify.cc
@@ -10,7 +10,8 @@ namespace NodeInotify {
         exports->Set(Nan::New<String>("version").ToLocalChecked(),
                     Nan::New<String>(NODE_INOTIFY_VERSION).ToLocalChecked());
 
-        Local<ObjectTemplate> global = ObjectTemplate::New();
+        v8::Isolate* isolate = v8::Isolate::GetCurrent();
+        Local<ObjectTemplate> global = ObjectTemplate::New(isolate);
         Handle<Context> context = Nan::New<Context>(reinterpret_cast<ExtensionConfiguration *>(NULL), global);
         Context::Scope context_scope(context);
 


### PR DESCRIPTION
The changes in this merge request address the build errors observed when using Node 10 and  continue to work for Node 8 too.

There are still various other warnings that get raised but this is the smallest change that allows this library to work with Node 8 and 10 (I have not tested other versions.

Fixes #68 and #69.