### PR TITLE
Add node 12.4.0 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew=="
     },
     "nan": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "main": "inotify",
   "dependencies": {
     "bindings": "^1.3.1",
-    "nan": "^2.12.1"
+    "nan": "^2.14.0"
   },
   "scripts": {
     "test": "node-gyp configure build"

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -7,7 +7,7 @@ namespace NodeInotify {
 
 	class Inotify : public Nan::ObjectWrap {
 		public:
-			static void Initialize(Handle<Object> target);
+			static void Initialize(Local<Object> target);
 
 			Inotify();
 			Inotify(bool nonpersistent);

--- a/src/node_inotify.cc
+++ b/src/node_inotify.cc
@@ -2,23 +2,27 @@
 #include "bindings.h"
 
 namespace NodeInotify {
-    void InitializeInotify(Handle<Object> exports) {
+    void InitializeInotify(Local<Object> exports) {
         Nan::HandleScope scope;
 
         Inotify::Initialize(exports);
 
+	auto i = v8::Isolate::GetCurrent();
+	auto ctx = i->GetCurrentContext();
+
+	// FIXME: The maybe version fails here
         exports->Set(Nan::New<String>("version").ToLocalChecked(),
                     Nan::New<String>(NODE_INOTIFY_VERSION).ToLocalChecked());
 
         v8::Isolate* isolate = v8::Isolate::GetCurrent();
         Local<ObjectTemplate> global = ObjectTemplate::New(isolate);
-        Handle<Context> context = Nan::New<Context>(reinterpret_cast<ExtensionConfiguration *>(NULL), global);
+        Local<Context> context = Nan::New<Context>(reinterpret_cast<ExtensionConfiguration *>(NULL), global);
         Context::Scope context_scope(context);
 
         context->Global()->Set(Nan::New<String>("Inotify").ToLocalChecked(), exports);
     }
 
-    extern "C" void init (Handle<Object> exports) {
+    extern "C" void init (Local<Object> exports) {
         Nan::HandleScope scope;
         InitializeInotify(exports);
     }

--- a/src/node_inotify.h
+++ b/src/node_inotify.h
@@ -11,7 +11,8 @@
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include "nan.h"
+#include <nan.h>
+
 #define NODE_INOTIFY_VERSION "1.3.0"
 
 using namespace v8;


### PR DESCRIPTION
Made some changes so it (at least) compiles & usable.


There are still some warnings remain to be solved. I tried my best to replace all deprecated usages with (working) new ones, however almost all new ones have return values, and they're ignored for now.


It's not tested on old versions.