### PR TITLE
Add node v14 support 

### DIFF
--- a/src/node_inotify.cc
+++ b/src/node_inotify.cc
@@ -4,22 +4,18 @@
 namespace NodeInotify {
     void InitializeInotify(Local<Object> exports) {
         Nan::HandleScope scope;
-
-        Inotify::Initialize(exports);
-
-	auto i = v8::Isolate::GetCurrent();
-	auto ctx = i->GetCurrentContext();
-
-	// FIXME: The maybe version fails here
-        exports->Set(Nan::New<String>("version").ToLocalChecked(),
-                    Nan::New<String>(NODE_INOTIFY_VERSION).ToLocalChecked());
-
         v8::Isolate* isolate = v8::Isolate::GetCurrent();
         Local<ObjectTemplate> global = ObjectTemplate::New(isolate);
         Local<Context> context = Nan::New<Context>(reinterpret_cast<ExtensionConfiguration *>(NULL), global);
-        Context::Scope context_scope(context);
+        Inotify::Initialize(exports);
 
-        context->Global()->Set(Nan::New<String>("Inotify").ToLocalChecked(), exports);
+        auto i = v8::Isolate::GetCurrent();
+        // auto ctx = i->GetCurrentContext();
+        // FIXME: The maybe version fails here
+        exports->Set(context, Nan::New<String>("version").ToLocalChecked(),
+                    Nan::New<String>(NODE_INOTIFY_VERSION).ToLocalChecked());
+        Context::Scope context_scope(context);
+        context->Global()->Set(context,Nan::New<String>("Inotify").ToLocalChecked(), exports);
     }
 
     extern "C" void init (Local<Object> exports) {

--- a/src/node_inotify.h
+++ b/src/node_inotify.h
@@ -2,6 +2,16 @@
 #ifndef SRC_NODE_INOTIFY_H_
 #define SRC_NODE_INOTIFY_H_
 
+// Silence incompatible cast warning from Nan::AsyncQueueWorker(Nan::AsyncWorker*)
+// https://github.com/nodejs/nan/issues/807
+#if defined(__GNUC__) && __GNUC__ >= 8
+#define DISABLE_WCAST_FUNCTION_TYPE _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wcast-function-type\"")
+#define DISABLE_WCAST_FUNCTION_TYPE_END _Pragma("GCC diagnostic pop")
+#else
+#define DISABLE_WCAST_FUNCTION_TYPE
+#define DISABLE_WCAST_FUNCTION_TYPE_END
+#endif
+
 #include <node.h>
 #include <node_version.h>
 #include <node_object_wrap.h>
@@ -11,7 +21,9 @@
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
+DISABLE_WCAST_FUNCTION_TYPE
 #include <nan.h>
+DISABLE_WCAST_FUNCTION_TYPE_END
 
 #define NODE_INOTIFY_VERSION "1.3.0"
 
@@ -23,4 +35,3 @@ namespace NodeInotify {
 }
 
 #endif  // SRC_NODE_INOTIFY_H_
-


### PR DESCRIPTION
Fix some compilation errors, so it now compiles and tested (albeit with an extremely simple case) on node `v14.2.0`.

I silenced some `cast-function-type` warnings, but there are still warnings about unhandled return types..

If you have more test/benchmark cases, can run them as well.

PS Not tested on older node versions..